### PR TITLE
Pin poetry to <1.2 as git dependencies do not work as we want them

### DIFF
--- a/.github/workflows/python-ci-e2e.yml
+++ b/.github/workflows/python-ci-e2e.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install python dependencies
         run: |
           pip3 install pip==22.0.3
-          pip3 install poetry
+          pip3 install poetry<1.2
           make install
       - name: Lint with flake8 (black and isort)
         run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install python dependencies
         run: |
           pip3 install pip==22.0.3
-          pip3 install poetry
+          pip3 install poetry<1.2
           make install
       - name: Lint with flake8 (black and isort)
         run: |


### PR DESCRIPTION
See https://python-poetry.org/blog/announcing-poetry-1.2.0/#native-python-git-client