### PR TITLE
Allow postgres image and apt packages to be customized

### DIFF
--- a/.github/workflows/python-ci-e2e.yml
+++ b/.github/workflows/python-ci-e2e.yml
@@ -16,6 +16,14 @@ on:
         type: string
         required: false
         default: '>=1.4.0,<1.5'
+      postgres_image:
+        type: string
+        required: false
+        default: 'postgres'
+      apt_extra_packages:
+        type: string
+        required: false
+        default: ""
       artifact_name:
         type: string
       artifact_path:
@@ -28,7 +36,7 @@ jobs:
   linting-and-tests:
     services:
       postgres:
-        image: postgres
+        image: ${{ inputs.postgres_image }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -59,7 +67,7 @@ jobs:
       - name: Install additional software
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libssl-dev libcurl4-openssl-dev
+          sudo apt-get install -y libssl-dev libcurl4-openssl-dev ${{ inputs.apt_extra_packages }}
       - name: Install python dependencies
         env:
           PYCURL_SSL_LIBRARY: openssl

--- a/.github/workflows/python-ci-e2e.yml
+++ b/.github/workflows/python-ci-e2e.yml
@@ -20,6 +20,10 @@ on:
         type: string
         required: false
         default: 'postgres'
+      database_protocol:
+        type: string
+        required: false
+        default: 'postgres'
       apt_extra_packages:
         type: string
         required: false
@@ -80,13 +84,13 @@ jobs:
           make lint
       - name: Run the unit/functional testsuite
         env:
-          DATABASE_URL: 'postgres://postgres:postgres@localhost/${{ inputs.name }}'
+          DATABASE_URL: '${{ inputs.database_protocol }}://postgres:postgres@localhost/${{ inputs.name }}'
         run: |
           source $(poetry env info --path)/bin/activate
           make test
       - name: Run the e2e testsuite
         env:
-          DATABASE_URL: 'postgres://postgres:postgres@localhost/${{ inputs.name }}'
+          DATABASE_URL: '${{ inputs.database_protocol }}://postgres:postgres@localhost/${{ inputs.name }}'
           DJANGO_ALLOW_ASYNC_UNSAFE: true
         run: |
           source $(poetry env info --path)/bin/activate

--- a/.github/workflows/python-ci-e2e.yml
+++ b/.github/workflows/python-ci-e2e.yml
@@ -11,19 +11,19 @@ on:
       pip_version:
         type: string
         required: false
-        default: '>=23,<23.1'
+        default: ">=23,<23.1"
       poetry_version:
         type: string
         required: false
-        default: '>=1.4.0,<1.5'
+        default: ">=1.4.0,<1.5"
       postgres_image:
         type: string
         required: false
-        default: 'postgres'
+        default: "postgres"
       database_protocol:
         type: string
         required: false
-        default: 'postgres'
+        default: "postgres"
       apt_extra_packages:
         type: string
         required: false
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python ${{ inputs.python_version }}
         uses: actions/setup-python@v4
         with:
-           python-version: '${{ inputs.python_version }}'
+          python-version: "${{ inputs.python_version }}"
       - name: Setup ssh:// to https:// mapping with a token
         run: |
           git config --global url."https://${{ secrets.TECHONOMY_REPOS_GITHUB_TOKEN }}@github.com/".insteadOf ssh://git@github.com/
@@ -84,13 +84,13 @@ jobs:
           make lint
       - name: Run the unit/functional testsuite
         env:
-          DATABASE_URL: '${{ inputs.database_protocol }}://postgres:postgres@localhost/${{ inputs.name }}'
+          DATABASE_URL: "${{ inputs.database_protocol }}://postgres:postgres@localhost/${{ inputs.name }}"
         run: |
           source $(poetry env info --path)/bin/activate
           make test
       - name: Run the e2e testsuite
         env:
-          DATABASE_URL: '${{ inputs.database_protocol }}://postgres:postgres@localhost/${{ inputs.name }}'
+          DATABASE_URL: "${{ inputs.database_protocol }}://postgres:postgres@localhost/${{ inputs.name }}"
           DJANGO_ALLOW_ASYNC_UNSAFE: true
         run: |
           source $(poetry env info --path)/bin/activate

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,6 +20,10 @@ on:
         type: string
         required: false
         default: 'postgres'
+      database_protocol:
+        type: string
+        required: false
+        default: 'postgres'
       apt_extra_packages:
         type: string
         required: false
@@ -71,7 +75,7 @@ jobs:
           make lint
       - name: Run the unit/functional testsuite
         env:
-          DATABASE_URL: 'postgres://postgres:postgres@localhost/${{ inputs.name }}'
+          DATABASE_URL: '${{ inputs.database_protocol }}://postgres:postgres@localhost/${{ inputs.name }}'
         run: |
           source $(poetry env info --path)/bin/activate
           make test

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,6 +16,14 @@ on:
         type: string
         required: false
         default: '>=1.4.0,<1.5'
+      postgres_image:
+        type: string
+        required: false
+        default: 'postgres'
+      apt_extra_packages:
+        type: string
+        required: false
+        default: ""
     secrets:
       TECHONOMY_REPOS_GITHUB_TOKEN:
         required: true
@@ -24,7 +32,7 @@ jobs:
   linting-and-tests:
     services:
       postgres:
-        image: postgres
+        image: ${{ inputs.postgres_image }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -50,7 +58,7 @@ jobs:
       - name: Install additional software
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libssl-dev libcurl4-openssl-dev
+          sudo apt-get install -y libssl-dev libcurl4-openssl-dev ${{ inputs.apt_extra_packages }}
       - name: Install python dependencies
         env:
           PYCURL_SSL_LIBRARY: openssl

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -11,19 +11,19 @@ on:
       pip_version:
         type: string
         required: false
-        default: '>=23,<23.1'
+        default: ">=23,<23.1"
       poetry_version:
         type: string
         required: false
-        default: '>=1.4.0,<1.5'
+        default: ">=1.4.0,<1.5"
       postgres_image:
         type: string
         required: false
-        default: 'postgres'
+        default: "postgres"
       database_protocol:
         type: string
         required: false
-        default: 'postgres'
+        default: "postgres"
       apt_extra_packages:
         type: string
         required: false
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python ${{ inputs.python_version }}
         uses: actions/setup-python@v4
         with:
-           python-version: '${{ inputs.python_version }}'
+          python-version: "${{ inputs.python_version }}"
       - name: Setup ssh:// to https:// mapping with a token
         run: |
           git config --global url."https://${{ secrets.TECHONOMY_REPOS_GITHUB_TOKEN }}@github.com/".insteadOf ssh://git@github.com/
@@ -75,7 +75,7 @@ jobs:
           make lint
       - name: Run the unit/functional testsuite
         env:
-          DATABASE_URL: '${{ inputs.database_protocol }}://postgres:postgres@localhost/${{ inputs.name }}'
+          DATABASE_URL: "${{ inputs.database_protocol }}://postgres:postgres@localhost/${{ inputs.name }}"
         run: |
           source $(poetry env info --path)/bin/activate
           make test


### PR DESCRIPTION
Use-case: we need to enable GeoDjango for a project. This requires us to use a different postgres image and install some support packages.