### PR TITLE
Add configure frontend environment file step

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -15,6 +15,10 @@ on:
       node_version:
         type: string
         required: true
+      env_file:
+        type: string
+        default: ''
+        required: false
     secrets:
       PACKAGE_GITHUB_TOKEN:
         required: true
@@ -40,6 +44,12 @@ jobs:
       - name: Configure git
         run: |
           git config --global url."https://${{ secrets.TECHONOMY_REPOS_GITHUB_TOKEN }}@github.com/".insteadOf git@github.com:
+      - name: Configure environment file
+        if: ${{ inputs.env_file != '' }}
+        run: |
+          cp ${{ inputs.env_file }} .env
+          # Remove all potential other env files to avoid conflicts
+          rm .env.*
       - name: Install frontend dependencies
         run: |
           npx yarn --cwd  ${{ inputs.working_directory }} install


### PR DESCRIPTION
**General use-case**
sometimes variables need to be configured at build time. Environment files can support this, but configuring the right file must happen inside the reusable workflow to have an effect.

**Practical example**
For [clubchamp-survey](https://github.com/techonomydev/clubchamp-survey), the POST url depends on the environment (production / testing). We need to be able to configure this url using an environment variable.