### PR TITLE
Update aws-actions/configure-aws-credential to v4

### DIFF
--- a/.github/workflows/deploy-static-website.yml
+++ b/.github/workflows/deploy-static-website.yml
@@ -32,7 +32,7 @@ jobs:
         run:
           pip install awscli
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v3
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -37,7 +37,7 @@ jobs:
         run:
           pip install -r etc/requirements-aws.txt
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Changelog: https://github.com/aws-actions/configure-aws-credentials/blob/main/CHANGELOG.md

This action uses an updated AWS SDK. The AWS SDK used by the previous version of this action is outdated.


I've verified the action continue to works like expected, see https://github.com/techonomydev/buurtsportcoach-planner/actions/runs/6296965550/job/17092977762